### PR TITLE
Fix broken date when pick time is disabled

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1045,9 +1045,13 @@
                     if ($(e.target).is('.new')) {
                         day.add(1, 'M');
                     }
-                    setValue(day.date(parseInt($(e.target).text(), 10)));
-                    if (!hasTime() && !options.keepOpen && !options.inline) {
-                        hide();
+                    if (!hasTime()) {
+                        setValue(day.date(parseInt($(e.target).text(), 10)).startOf('day'));
+                        if (!options.keepOpen && !options.inline) {
+                            hide();
+                        }
+                    } else {
+                        setValue(day.date(parseInt($(e.target).text(), 10)));
                     }
                 },
 


### PR DESCRIPTION
What:
In 4.17.37 when the time picker was disabled the moment object returned by
the onChange event was a start of day date.
Since 4.17.42 this is no longer the case (#2083).

Why:
4.17.42 fixed a bug and among other things removed a call to startOf('day') on a moment.

How:
Introducing this startOf('day') call when a date is picked: if the time
picker is disabled, startOf('day') is called on the moment to set, else it isn't called.

This repo is no longer actively monitor or supported. All future work is being done to https://github.com/tempusdominus/bootstrap-3 
