### PR TITLE
Show decades from 1900-1910, 1910-1920, etc.

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -671,8 +671,8 @@
                     minDateDecade = options.minDate && options.minDate.isAfter(startDecade, 'y') && options.minDate.year() <= endDecadeYear;
                     maxDateDecade = options.maxDate && options.maxDate.isAfter(startDecade, 'y') && options.maxDate.year() <= endDecadeYear;
                     html += '<span data-action="selectDecade" class="decade' + (date.isAfter(startDecade) && date.year() <= endDecadeYear ? ' active' : '') +
-                        (!isValid(startDecade, 'y') && !minDateDecade && !maxDateDecade ? ' disabled' : '') + '" data-selection="' + (startDecade.year() + 6) + '">' + (startDecade.year() + 1) + ' - ' + (startDecade.year() + 12) + '</span>';
-                    startDecade.add(12, 'y');
+                        (!isValid(startDecade, 'y') && !minDateDecade && !maxDateDecade ? ' disabled' : '') + '" data-selection="' + (startDecade.year() + 6) + '">' + (startDecade.year() + 1) + ' - ' + (startDecade.year() + 11) + '</span>';
+                    startDecade.add(10, 'y');
                 }
                 html += '<span></span><span></span><span></span>'; //push the dangling block over, at least this way it's even
 


### PR DESCRIPTION
Previously decades where shown with uneven numbers making it hard to find stuff.

Also this change fit's nicely with my next PR.

[Old](https://www.dropbox.com/s/78kvlopcrthelc1/Screenshot%202016-05-06%2013.24.51.png?dl=1)
[New](https://www.dropbox.com/s/gjt11eau6c50nz0/Screenshot%202016-05-06%2013.21.14.png?dl=1)

This repo is no longer actively monitor or supported. All future work is being done to https://github.com/tempusdominus/bootstrap-3 
