### PR TITLE
Hide picker when clicking outside

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1429,6 +1429,7 @@
          ********************************************************************************/
         picker.destroy = function () {
             ///<summary>Destroys the widget and removes all attached event listeners</summary>
+            $(document).off('mousedown', clickedOutside);
             hide();
             detachDatePickerElementEvents();
             element.removeData('DateTimePicker');
@@ -1440,6 +1441,15 @@
         picker.show = show;
 
         picker.hide = hide;
+
+        picker.clickedOutside = function (e) {
+            // Clicked outside the datetimepicker, hide it
+            if ($(e.target).closest('.datetimepicker').length === 0) {
+                hide();
+            }
+        };
+
+        $(document).on('mousedown', picker.clickedOutside);
 
         picker.disable = function () {
             ///<summary>Disables the input element, the component is attached to, by adding a disabled="true" attribute to it.


### PR DESCRIPTION
Useful when focusOnShow=false. See https://github.com/Eonasdan/bootstrap-datetimepicker/issues/1277#issuecomment-219277607

This repo is no longer actively monitor or supported. All future work is being done to https://github.com/tempusdominus/bootstrap-3 
